### PR TITLE
build: Correct use of multiple instances of the licence plugin

### DIFF
--- a/lwf-stubs/pom.xml
+++ b/lwf-stubs/pom.xml
@@ -49,10 +49,6 @@
         <artifactId>maven-compiler-plugin</artifactId>
       </plugin>
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>license-maven-plugin</artifactId>
-      </plugin>
-      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
       </plugin>

--- a/mipav-stubs/pom.xml
+++ b/mipav-stubs/pom.xml
@@ -49,10 +49,6 @@
         <artifactId>maven-compiler-plugin</artifactId>
       </plugin>
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>license-maven-plugin</artifactId>
-      </plugin>
-      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
       </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -177,7 +177,6 @@
     - Board of Regents of the University of Wisconsin-Madison
     - Glencoe Software, Inc.
     - University of Dundee</organizationName>
-            <projectName>Contains the OME imaging metadata model specification, code generator and implementation</projectName>
             <addJavaLicenseAfterPackage>false</addJavaLicenseAfterPackage>
             <canUpdateDescription>true</canUpdateDescription>
             <!-- NB: Avoid stomping on variant copyright holders. -->


### PR DESCRIPTION
Testing: Check warning is no longer present.

Also, removed broken projectName.  Was incorrect, and it defaults to the current project.name, so was pointless.