### PR TITLE
Update publication build system to use Central Portal

### DIFF
--- a/mipav-stubs/pom.xml
+++ b/mipav-stubs/pom.xml
@@ -16,11 +16,11 @@
 
   <name>MIPAV stubs</name>
   <description>Stubs of MIPAV Java classes required to compile Bio-Formats' MIPAV plugin.</description>
-  <url>http://mipav.cit.nih.gov</url>
+  <url>https://mipav.cit.nih.gov</url>
   <inceptionYear>2010</inceptionYear>
   <organization>
     <name>Open Microscopy Environment</name>
-    <url>http://www.openmicroscopy.org/</url>
+    <url>https://www.openmicroscopy.org/</url>
   </organization>
   <licenses>
     <license>

--- a/pom.xml
+++ b/pom.xml
@@ -144,11 +144,12 @@
         <plugin>
 	  <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-compiler-plugin</artifactId>
-          <version>3.7.0</version>
+          <version>3.14.0</version>
           <!-- Require the Java 8 platform. -->
           <configuration>
-            <source>1.8</source>
-            <target>1.8</target>
+            <source>8</source>
+            <target>8</target>
+            <release>8</release>
           </configuration>
         </plugin>
 

--- a/pom.xml
+++ b/pom.xml
@@ -12,11 +12,11 @@
 
   <name>OME Stubs</name>
   <description>Components that are stubs of other external projects.</description>
-  <url>http://www.openmicroscopy.org/site/products/bio-formats</url>
+  <url>https://www.openmicroscopy.org/bio-formats</url>
   <inceptionYear>2005</inceptionYear>
   <organization>
     <name>Open Microscopy Environment</name>
-    <url>http://www.openmicroscopy.org/</url>
+    <url>https://www.openmicroscopy.org/</url>
   </organization>
   <licenses>
     <license>
@@ -29,7 +29,7 @@
   <developers>
     <developer>
       <name>The OME Team</name>
-      <email>ome-devel@lists.openmicroscopy.org.uk</email>
+      <url>https://www.openmicroscopy.org/teams/</url>
     </developer>
   </developers>
   <contributors>
@@ -48,23 +48,6 @@
     <contributor><name>Bjoern Thiel</name></contributor>
   </contributors>
 
-  <mailingLists>
-    <mailingList>
-      <name>OME-users</name>
-      <subscribe>http://lists.openmicroscopy.org.uk/mailman/listinfo/ome-users/</subscribe>
-      <unsubscribe>http://lists.openmicroscopy.org.uk/mailman/listinfo/ome-users/</unsubscribe>
-      <post>ome-users@lists.openmicroscopy.org.uk</post>
-      <archive>http://lists.openmicroscopy.org.uk/pipermail/ome-users/</archive>
-    </mailingList>
-    <mailingList>
-      <name>OME-devel</name>
-      <subscribe>http://lists.openmicroscopy.org.uk/mailman/listinfo/ome-devel/</subscribe>
-      <unsubscribe>http://lists.openmicroscopy.org.uk/mailman/listinfo/ome-devel/</unsubscribe>
-      <post>ome-devel@lists.openmicroscopy.org.uk</post>
-      <archive>http://lists.openmicroscopy.org.uk/pipermail/ome-devel/</archive>
-    </mailingList>
-  </mailingLists>
-
   <prerequisites>
     <maven>3.0.5</maven>
   </prerequisites>
@@ -77,15 +60,15 @@
     <connection>scm:git:https://github.com/ome/ome-stubs</connection>
     <developerConnection>scm:git:git@github.com:ome/ome-stubs</developerConnection>
     <tag>HEAD</tag>
-    <url>http://github.com/ome/ome-stubs</url>
+    <url>https://github.com/ome/ome-stubs</url>
   </scm>
   <issueManagement>
     <system>Trac</system>
-    <url>https://trac.openmicroscopy.org/ome</url>
+    <url>https://github.com/ome/ome-stubs/issues</url>
   </issueManagement>
   <ciManagement>
     <system>Jenkins</system>
-    <url>https://ci.openmicroscopy.org/</url>
+    <url>https://github.com/ome/ome-stubs/actions</url>
   </ciManagement>
 
   <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -233,7 +233,7 @@
           <configuration>
             <failOnError>false</failOnError>
             <links>
-              <link>http://docs.oracle.com/javase/7/docs/api/</link>
+              <link>http://docs.oracle.com/javase/8/docs/api/</link>
             </links>
           </configuration>
           <executions>

--- a/pom.xml
+++ b/pom.xml
@@ -87,16 +87,6 @@
     <system>Jenkins</system>
     <url>https://ci.openmicroscopy.org/</url>
   </ciManagement>
-  <distributionManagement>
-    <snapshotRepository>
-      <id>ossrh</id>
-      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-    </snapshotRepository>
-    <repository>
-      <id>ossrh</id>
-      <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
-    </repository>
-  </distributionManagement>
 
   <properties>
     <!-- If two artifacts on the classpath use two different versions of the
@@ -364,19 +354,6 @@
       <id>release</id>
       <build>
         <plugins>
-          <!-- Stage releases with nexus -->
-          <plugin>
-            <groupId>org.sonatype.plugins</groupId>
-            <artifactId>nexus-staging-maven-plugin</artifactId>
-            <version>1.6.8</version>
-            <extensions>true</extensions>
-            <configuration>
-              <serverId>ossrh</serverId>
-              <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-              <autoReleaseAfterClose>false</autoReleaseAfterClose>
-            </configuration>
-          </plugin>
-
           <!-- gpg release signing -->
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
@@ -391,6 +368,17 @@
                 </goals>
               </execution>
             </executions>
+          </plugin>
+
+          <plugin>
+            <groupId>org.sonatype.central</groupId>
+            <artifactId>central-publishing-maven-plugin</artifactId>
+            <version>0.8.0</version>
+            <extensions>true</extensions>
+            <configuration>
+              <publishingServerId>central</publishingServerId>
+              <tokenAuth>true</tokenAuth>
+            </configuration>
           </plugin>
         </plugins>
       </build>


### PR DESCRIPTION
See https://central.sonatype.org/news/20250326_ossrh_sunset/ for more context as well as https://github.com/ome/ome-common-java/pull/101 and https://github.com/ome/ome-contributing/pull/37

- adjusts the `release` profile to use `central-publishing-maven-plugin` and remove OSSRH repositories
- update `maven-compiler-plugin` to 3.14.0 and set the release target to 8 - see https://maven.apache.org/plugins/maven-compiler-plugin/examples/set-compiler-release.html#usage-on-jdk-8
- remove or update outdated metadata
