### PR TITLE
Require Java 11 at runtime, build on Java 21/25

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -13,15 +13,15 @@ jobs:
   build:
     strategy:
       matrix:
-        java: [8, 11, 17, 21]
+        java: [21, 25]
         os: [ubuntu-latest, windows-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     env:
       maven_commands: install # default is install
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set up JDK ${{ matrix.java }}
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: ${{ matrix.java }}
           distribution: 'zulu'

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -13,7 +13,7 @@ jobs:
   build:
     strategy:
       matrix:
-        java: [21, 25]
+        java: [11, 17, 21, 25]
         os: [ubuntu-latest, windows-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     env:

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ following before submitting a pull request:
  * verify that the branch merges cleanly into ```develop```
  * verify that the branch compiles with the ```clean jars tools``` Ant targets
  * verify that the branch compiles using Maven
- * verify that the branch does not use syntax or API specific to Java 1.8+
+ * verify that the branch does not use syntax or API specific to Java > 11
  * run the unit tests (```ant test```) and correct any failures
  * test at least one file in each affected format, using the ```showinf```
    command

--- a/pom.xml
+++ b/pom.xml
@@ -128,11 +128,9 @@
 	  <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-compiler-plugin</artifactId>
           <version>3.14.0</version>
-          <!-- Require the Java 8 platform. -->
+          <!-- Require the Java 11 platform. -->
           <configuration>
-            <source>8</source>
-            <target>8</target>
-            <release>8</release>
+            <release>11</release>
           </configuration>
         </plugin>
 
@@ -229,11 +227,11 @@
           <artifactId>maven-javadoc-plugin</artifactId>
           <!-- NB: The same version declaration and configuration block also
                appears in the <reporting> section, and must be kept in sync. -->
-          <version>3.0.1</version>
+          <version>3.12.0</version>
           <configuration>
             <failOnError>false</failOnError>
             <links>
-              <link>http://docs.oracle.com/javase/8/docs/api/</link>
+              <link>https://docs.oracle.com/en/java/javase/11/docs/api/</link>
             </links>
           </configuration>
           <executions>


### PR DESCRIPTION
See https://www.openmicroscopy.org/2026/03/24/end-of-java-8-support.html. Similar to https://github.com/ome/ome-metakit/pull/33.